### PR TITLE
add schema for dataset meta.json

### DIFF
--- a/schemata/dataset-metadata.schema.json
+++ b/schemata/dataset-metadata.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+
+  "title": "VDI Dataset Metadata",
+
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "type": {
+      "$ref": "#/definitions/dataset-type"
+    },
+    "projects": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true,
+      "additionalItems": false
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dataset-dependency"
+      },
+      "uniqueItems": true,
+      "additionalItems": false
+    }
+  },
+
+  "required": [
+    "type",
+    "projects",
+    "owner",
+    "name"
+  ],
+
+  "definitions": {
+    "dataset-type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "dataset-dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resourceIdentifier": {
+          "type": "string"
+        },
+        "resourceVersion": {
+          "type": "string"
+        },
+        "resourceDisplayName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "resourceIdentifier",
+        "resourceVersion",
+        "resourceDisplayName"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The following JSON examples are valid against this schema.

**Common Usecase**
```json
{
  "type": {
    "name": "BIOM",
    "version": "1.0"
  },
  "projects": [
    "PlasmoDB",
    "VectorBase"
  ],
  "owner": "123456789",
  "name": "My Okay Dataset",
  "summary": "It's just okay",
  "description": "Nothing special about it.",
  "dependencies": [
    {
      "resourceIdentifier": "something1",
      "resourceVersion": "something1",
      "resourceDisplayName": "something1"
    },
    {
      "resourceIdentifier": "something2",
      "resourceVersion": "something2",
      "resourceDisplayName": "something2"
    }
  ]
}
```

**Minimum Required**
```json
{
  "type": {
    "name": "A",
    "version": "B"
  },
  "projects": [
    "C"
  ],
  "owner": "D",
  "name": "E"
}
```