### PR TITLE
Add manifest json schema

### DIFF
--- a/schemata/dataset-manifest.schema.json
+++ b/schemata/dataset-manifest.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+
+  "title": "VDI Dataset Manifest",
+
+  "type": "object",
+  "additionalProperties": false,
+
+  "properties": {
+    "inputFiles": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true,
+      "additionalItems": false
+    },
+    "dataFiles": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true,
+      "additionalItems": false
+    }
+  },
+
+  "required": [
+    "inputFiles",
+    "dataFiles"
+  ]
+}


### PR DESCRIPTION
JSON schema definition for a dataset's `manifest.json` file.

Example JSON:
```json
{
  "inputFiles": [
    "my-dog.jpg",
    "w2.pdf",
    "birthday.mp4"
  ],
  "dataFiles": [
    "001.biom",
    "002.biom",
  ]
}
```