### PR TITLE
Script execution wrapper.

### DIFF
--- a/util-handler-server/src/main/kotlin/vdi/util/script/ScriptExecutor.kt
+++ b/util-handler-server/src/main/kotlin/vdi/util/script/ScriptExecutor.kt
@@ -1,0 +1,65 @@
+package vdi.util.script
+
+import java.io.File
+
+/**
+ * Script Executor
+ *
+ * Script/process execution manager.
+ *
+ * This type is used over direct use of Java's [ProcessBuilder] to allow for
+ * unit testing of functions that execute command line scripts.
+ */
+interface ScriptExecutor {
+
+  /**
+   * Executes the target command in the target working directory and calls the
+   * given function on the running [ScriptProcess] instance.
+   *
+   * This function waits to return until after the script has exited.
+   *
+   * **Example**
+   * ```kotlin
+   * // This sample execution runs "myCommand" in the directory "here" and
+   * // requiring the execution of the command to complete within 3600 seconds
+   * // then returns "success" or "failure" based on whether the command's exit
+   * // code.
+   * val result = ScriptExecutor("myCommand", File("here")) {
+   *   waitFor(timeoutSeconds = 3600)
+   *
+   *   return if (exitCode() == 0)
+   *     "success"
+   *   else
+   *     "failure"
+   * }
+   * ```
+   *
+   * @param command Name of or path to the command to execute.
+   *
+   * @param workDir Context directory from which the command will be executed.
+   *
+   * @param arguments Optional array of additional arguments to pass to the
+   * command being executed.
+   *
+   * @param environment Optional environment variables to set for the command
+   * being executed.
+   *
+   * @param fn Function that is executed on the started [ScriptProcess]
+   * instance.  This function will be called once, immediately after the target
+   * command is started without regard to whether the command is still running
+   * or has already exited.  The function is expected to make that determination
+   * itself and act accordingly.
+   *
+   * @param T Return type of the function that consumes the running process.
+   *
+   * @return Returns the value returned by the given function.
+   */
+  suspend fun <T> executeScript(
+    command: String,
+    workDir: File,
+    arguments: Array<String> = emptyArray(),
+    environment: Map<String, String> = emptyMap(),
+    fn: ScriptProcess.() -> T
+  ): T
+}
+

--- a/util-handler-server/src/main/kotlin/vdi/util/script/ScriptExecutorImpl.kt
+++ b/util-handler-server/src/main/kotlin/vdi/util/script/ScriptExecutorImpl.kt
@@ -1,0 +1,27 @@
+package vdi.util.script
+
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ScriptExecutorImpl : ScriptExecutor {
+  override suspend fun <T> executeScript(
+    command:     String,
+    workDir:     File,
+    arguments:   Array<String>,
+    environment: Map<String, String>,
+    fn:          ScriptProcess.() -> T,
+  ): T = withContext(Dispatchers.IO) {
+    val rawProcess = ProcessBuilder(command, *arguments).apply {
+      directory(workDir)
+      environment().clear()
+      environment().putAll(environment)
+    }.start()
+
+    val out = fn(ScriptProcessImpl(rawProcess))
+
+    rawProcess.waitFor()
+
+    out
+  }
+}

--- a/util-handler-server/src/main/kotlin/vdi/util/script/ScriptProcess.kt
+++ b/util-handler-server/src/main/kotlin/vdi/util/script/ScriptProcess.kt
@@ -1,0 +1,48 @@
+package vdi.util.script
+
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Script Process
+ *
+ * Active or executed script process wrapper.
+ *
+ * This type is used over direct use of Java's [Process] type to allow for unit
+ * testing of functions that execute command line scripts.
+ */
+interface ScriptProcess {
+
+  /**
+   * The executed script's STDOUT stream.
+   */
+  val scriptStdOut: InputStream
+
+  /**
+   * The executed script's STDERR stream.
+   */
+  val scriptStdErr: InputStream
+
+  /**
+   * The executed script's STDIN stream.
+   */
+  val scriptStdIn: OutputStream
+
+  /**
+   * Requires that the script completes within the given duration (in seconds).
+   *
+   * If the script does not complete within the given duration, this method will
+   * forcibly kill the script and throw an exception.
+   *
+   * @param timeoutSeconds Number of seconds that the script execution must
+   * complete within.
+   *
+   * This parameter defaults to `-1`, which means if no timeout.
+   */
+  fun waitFor(timeoutSeconds: Long = -1)
+
+  /**
+   * Returns the exit code of the process.
+   */
+  fun exitCode(): Int
+}

--- a/util-handler-server/src/main/kotlin/vdi/util/script/ScriptProcessImpl.kt
+++ b/util-handler-server/src/main/kotlin/vdi/util/script/ScriptProcessImpl.kt
@@ -1,0 +1,35 @@
+package vdi.util.script
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+class ScriptProcessImpl(private val raw: Process) : ScriptProcess {
+  override val scriptStdOut: InputStream
+    get() = raw.inputStream
+
+  override val scriptStdErr: InputStream
+    get() = raw.errorStream
+
+  override val scriptStdIn: OutputStream
+    get() = raw.outputStream
+
+  override fun waitFor(timeoutSeconds: Long) {
+    if (timeoutSeconds > -1) {
+      if (!raw.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+        raw.destroyForcibly()
+        throw IllegalStateException(
+          "command " +
+            raw.info().command().get() +
+            " exceeded the configured maximum allowed execution time of " +
+            timeoutSeconds.seconds
+        )
+      }
+    } else {
+      raw.waitFor()
+    }
+  }
+
+  override fun exitCode() = raw.exitValue()
+}


### PR DESCRIPTION
This PR adds 2 interfaces and implementations of types that wrap Java's `ProcessBuilder` and `Process` types to both abstract away common logic that all script execution points will use and to allow unit testing the code that calls the handler plugin scripts.

The types are:

#### `ScriptExecutor` & `ScriptExecutorImpl`

Wraps Java's `ProcessBuilder` type with a mockable interface and a call method tailored to our script execution use case.

#### `ScriptProcess` & `ScriptProcessImpl`

Wraps Java's `Process` type with a mockable interface including methods tailored for our script execution use case.
